### PR TITLE
Feat/integrate-wallet-creation

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -70,6 +70,7 @@ export class AuthService {
             otpExpiryDate,
             photoUrl: firebaseUser.photoURL,
             signUpMethod: 'password',
+            planTier: 'free',
           },
         ],
         { session },

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -16,9 +16,9 @@ import {
   VerifyTokenDto,
 } from './dto';
 import { FirebaseService } from 'src/firebase/firebase.service';
-import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
-import { UserDoc } from 'src/database/schema';
+import { InjectConnection, InjectModel } from '@nestjs/mongoose';
+import mongoose, { Model } from 'mongoose';
+import { UserDoc, WalletDocument } from 'src/database/schema';
 import { DateTime } from 'luxon';
 import { UtilsService } from 'src/utils/utils.service';
 import { JwtService } from '@nestjs/jwt';
@@ -32,6 +32,8 @@ export class AuthService {
     private firebaseService: FirebaseService,
     private config: AppConfigService,
     @InjectModel('users') private userModel: Model<UserDoc>,
+    @InjectModel('wallets') private walletModel: Model<WalletDocument>,
+    @InjectConnection() private readonly connection: mongoose.Connection,
     private jwtService: JwtService,
     private util: UtilsService,
   ) {}
@@ -51,17 +53,53 @@ export class AuthService {
     );
 
     const { otp, otpExpiryDate } = this.generateOtp();
-    const user = this.userModel.create({
-      email: dto.email,
-      firebaseUserId: firebaseUser.uid,
-      firstName: dto.firstName,
-      lastName: dto.lastName,
-      name: dto.firstName + ' ' + dto.lastName,
-      otp,
-      otpExpiryDate,
-      photoUrl: firebaseUser.photoURL,
-      signUpMethod: 'password',
-    });
+    // start a mongoose session
+    const session = await this.connection.startSession();
+    let user;
+    try {
+      session.startTransaction();
+      [user] = await this.userModel.create(
+        [
+          {
+            email: dto.email,
+            firebaseUserId: firebaseUser.uid,
+            firstName: dto.firstName,
+            lastName: dto.lastName,
+            name: dto.firstName + ' ' + dto.lastName,
+            otp,
+            otpExpiryDate,
+            photoUrl: firebaseUser.photoURL,
+            signUpMethod: 'password',
+          },
+        ],
+        { session },
+      );
+
+      // create a new wallet for the user
+      const [newWallet] = await this.walletModel.create(
+        [
+          {
+            userId: user._id,
+            balance: 0,
+          },
+        ],
+        { session },
+      );
+
+      // update the user with the new wallet id
+      await this.userModel.findOneAndUpdate(
+        { _id: user._id },
+        { $set: { walletId: newWallet._id } },
+        { session },
+      );
+
+      await session.commitTransaction();
+    } catch (error) {
+      await session.abortTransaction();
+      throw error;
+    } finally {
+      await session.endSession();
+    }
 
     this.sendOtpToEmail(dto.email, otp).catch(() => undefined);
 

--- a/src/campaign/campaign.module.ts
+++ b/src/campaign/campaign.module.ts
@@ -3,8 +3,11 @@ import { CampaignService } from './campaign.service';
 import { CampaignController } from './campaign.controller';
 import { SqsProducerService } from './sqs-producer.service';
 import { CampaignWorkerService } from './campaign-worker.service';
-import { FacebookConsumerService } from './facebook-consumer.service';
+// import { FacebookConsumerService } from './facebook-consumer.service';
 import { JwtService } from '@nestjs/jwt';
+import { AmplifyWalletService } from './services/wallet.service';
+import { InternalHttpHelper } from '../common/helpers/internal-http.helper';
+import { ServiceRegistryService } from '../common/services/service-registry.service';
 
 @Module({
   providers: [
@@ -13,6 +16,9 @@ import { JwtService } from '@nestjs/jwt';
     CampaignWorkerService,
     // FacebookConsumerService,
     JwtService,
+    AmplifyWalletService,
+    InternalHttpHelper,
+    ServiceRegistryService,
   ],
   controllers: [CampaignController],
 })

--- a/src/campaign/dto/create-campaign.dto.ts
+++ b/src/campaign/dto/create-campaign.dto.ts
@@ -36,7 +36,7 @@ export class CreativeDto {
   @ApiProperty({
     description: 'The budget allocated specifically to this creative.',
     example: 500,
-    minimum: 0,
+    minimum: 1,
   })
   @IsNumber({}, { message: 'Budget must be a number.' })
   @Min(1, { message: 'Budget cannot be negative.' })

--- a/src/campaign/services/wallet.service.ts
+++ b/src/campaign/services/wallet.service.ts
@@ -1,0 +1,135 @@
+import { HttpException, HttpStatus, Injectable, Logger } from '@nestjs/common';
+import { InternalHttpHelper } from '../../common/helpers/internal-http.helper';
+
+interface ISubscriptionDetailsResponse {
+  data: {
+    planTier: 'free' | 'starter' | 'grow' | 'scale';
+    campaignLimit: number;
+  };
+  message: string;
+  success: boolean;
+}
+
+interface IWalletDebitResponse {
+  data: {
+    transactionId: string;
+    remainingBalance: number;
+  };
+  message: string;
+  success: boolean;
+}
+
+@Injectable()
+export class AmplifyWalletService {
+  private readonly logger = new Logger(AmplifyWalletService.name);
+  constructor(private internalHttpHelper: InternalHttpHelper) {}
+
+  async getSubscriptionDetails(userId: string) {
+    try {
+      // Make a request to the wallet service to get the user's subscription details
+      const response = await this.internalHttpHelper
+        .forService('amplify-wallet')
+        .get<ISubscriptionDetailsResponse>(
+          `/api/internal/subscription/subscription-details/${userId}`,
+        );
+
+      return response.data;
+    } catch (error) {
+      this.logger.error(
+        `::: Error fetching subscription plan for user => ${userId}`,
+      );
+      throw error;
+    }
+  }
+
+  async debitForCampaign(payload: {
+    userId: string;
+    amountInCents: number;
+    campaignId: string;
+  }) {
+    try {
+      // make a request to wallet service to debit the user's wallet
+      const response = await this.internalHttpHelper
+        .forService('amplify-wallet')
+        .post<IWalletDebitResponse>(
+          `/api/internal/wallet/debit-for-campaign`,
+          {
+            userId: payload.userId,
+            amountInCents: payload.amountInCents,
+          },
+          {
+            headers: {
+              'idempotency-key': payload.campaignId,
+            },
+          },
+        );
+
+      if (response.success) {
+        return response;
+      } else {
+        throw new Error(response.message);
+      }
+    } catch (error) {
+      this.logger.error(`::: Error debiting for campaign => ${error}`);
+
+      // The InternalHttpHelper throws a generic Error.
+      // Its message property contains the original service's error response stringified.
+      if (error instanceof Error) {
+        const errorMessage = error.message;
+        const responsePrefix = 'Response: ';
+        const responseIndex = errorMessage.indexOf(responsePrefix);
+
+        // Check if the error message contains the "Response: " prefix, indicating
+        // it's an error from an internal HTTP call.
+        if (responseIndex !== -1) {
+          // Extract the JSON string from the error message
+          const jsonString = errorMessage.substring(
+            responseIndex + responsePrefix.length,
+          );
+
+          let parsedErrorResponse;
+          try {
+            // Parse the JSON string to access the original error object from the wallet service
+            parsedErrorResponse = JSON.parse(jsonString);
+          } catch (jsonParseError) {
+            // Log a warning if the JSON parsing fails, but proceed to re-throw the original error
+            this.logger.warn(
+              `Failed to parse JSON from error message: ${jsonParseError}`,
+            );
+            throw error;
+          }
+
+          console.log(
+            `::: parse error message ${parsedErrorResponse} json string => ${jsonString} `,
+          );
+
+          // Check if the parsed response has the 'code' property and if it matches 'INSUFFICIENT_FUNDS'
+          if (
+            parsedErrorResponse &&
+            parsedErrorResponse.code === 'INSUFFICIENT_FUNDS'
+          ) {
+            // If it's an insufficient funds error, throw a 402 Payment Required exception
+            throw new HttpException(
+              {
+                message:
+                  'Payment Required: Insufficient wallet balance or wallet inactive.',
+                code: 'E_PAYMENT_REQUIRED', // You can define a custom error code for your API
+              },
+              HttpStatus.PAYMENT_REQUIRED, // 402 status code
+            );
+          } else {
+            throw new HttpException(
+              {
+                message: parsedErrorResponse?.message ?? 'Something went wrong',
+              },
+              parsedErrorResponse.statusCode ?? HttpStatus.BAD_REQUEST,
+            );
+          }
+        }
+      }
+      // Re-throw the original error if it's not the specific case we're looking for,
+      // or if it's not an Error instance that could be parsed (e.g., network error, etc.).
+      // throw error;
+    }
+  }
+}

--- a/src/common/helpers/internal-http.helper.ts
+++ b/src/common/helpers/internal-http.helper.ts
@@ -1,0 +1,143 @@
+import { Injectable, Logger } from '@nestjs/common';
+import axios, {
+  AxiosInstance,
+  AxiosRequestConfig,
+  AxiosResponse,
+  AxiosError,
+} from 'axios';
+import { ServiceRegistryService } from '../services/service-registry.service';
+import { ServiceName } from '../types/service.types';
+
+export interface InternalRequestOptions {
+  headers?: Record<string, string>;
+  timeout?: number;
+}
+
+@Injectable()
+export class InternalHttpHelper {
+  private readonly logger = new Logger(InternalHttpHelper.name);
+  private axiosInstance: AxiosInstance;
+  private baseUrl: string;
+  private serviceName: string;
+
+  constructor(private serviceRegistry: ServiceRegistryService) {
+    this.axiosInstance = axios.create({
+      timeout: 10000,
+    });
+  }
+
+  forService(serviceName: ServiceName): InternalHttpHelper {
+    this.serviceName = serviceName;
+    this.baseUrl = this.serviceRegistry.getServiceBaseUrl(serviceName);
+
+    this.logger.log(
+      `Configured internal HTTP helper for service: ${serviceName} with base URL: ${this.baseUrl}`,
+    );
+
+    return this;
+  }
+
+  async send<T = any>(
+    method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH',
+    url: string,
+    data?: any,
+    options: InternalRequestOptions = {},
+  ): Promise<T> {
+    if (!this.baseUrl) {
+      const error =
+        'Base URL not set. Call forService() before making requests.';
+      this.logger.error(error);
+      throw new Error(error);
+    }
+
+    const fullUrl = `${this.baseUrl}/${url.replace(/^\//, '')}`;
+
+    const requestId = `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+
+    const config: AxiosRequestConfig = {
+      method,
+      url: fullUrl,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Internal ${process.env.INTERNAL_REQUEST_TOKEN}`,
+        'X-Request-ID': requestId,
+        ...options.headers,
+      },
+      timeout: options.timeout || 10000,
+    };
+
+    if (['POST', 'PUT', 'PATCH'].includes(method) && data) {
+      config.data = data;
+    }
+
+    this.logger.debug(
+      `[${requestId}] Making ${method} request to ${this.serviceName} service: ${fullUrl}`,
+    );
+
+    try {
+      const response: AxiosResponse<T> =
+        await this.axiosInstance.request(config);
+      this.logger.debug(
+        `[${requestId}] Successful ${method} response from ${this.serviceName} service: ${fullUrl}`,
+      );
+      return response.data;
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        const axiosError = error as AxiosError;
+        const errorMessage = `Internal service call failed:
+          Service: ${this.serviceName}
+          Endpoint: ${fullUrl}
+          Method: ${method}
+          Status: ${axiosError.response?.status}
+          Request ID: ${requestId}
+          Error: ${axiosError.message}
+          Response: ${JSON.stringify(axiosError.response?.data)}`;
+
+        // this.logger.error(errorMessage);
+        throw new Error(errorMessage);
+      }
+
+      const genericError = `Unexpected error calling ${this.serviceName} service at ${fullUrl}: ${error.message}`;
+      this.logger.error(genericError);
+      throw new Error(genericError);
+    }
+  }
+
+  async get<T = any>(
+    url: string,
+    options?: InternalRequestOptions,
+  ): Promise<T> {
+    return this.send<T>('GET', url, undefined, options);
+  }
+
+  async post<T = any>(
+    url: string,
+    data?: any,
+    options?: InternalRequestOptions,
+  ): Promise<T> {
+    return this.send<T>('POST', url, data, options);
+  }
+
+  async put<T = any>(
+    url: string,
+    data?: any,
+    options?: InternalRequestOptions,
+  ): Promise<T> {
+    return this.send<T>('PUT', url, data, options);
+  }
+
+  async delete<T = any>(
+    url: string,
+    options?: InternalRequestOptions,
+  ): Promise<T> {
+    return this.send<T>('DELETE', url, undefined, options);
+  }
+
+  async patch<T = any>(
+    url: string,
+    data?: any,
+    options?: InternalRequestOptions,
+  ): Promise<T> {
+    return this.send<T>('PATCH', url, data, options);
+  }
+}

--- a/src/common/services/service-registry.service.ts
+++ b/src/common/services/service-registry.service.ts
@@ -1,0 +1,87 @@
+import { Injectable } from '@nestjs/common';
+import { ServiceName } from '../types/service.types';
+
+// Define available services as a union type for type safety
+// export type ServiceName = 'amplify-manager' | 'amplify-wallet';
+
+export interface ServiceConfig {
+  host: string;
+  port?: number; // Optional since it might be included in the host URL
+}
+
+@Injectable()
+export class ServiceRegistryService {
+  private registry: Record<ServiceName, ServiceConfig>;
+  private readonly stage: string;
+
+  constructor() {
+    this.stage = process.env.STAGE || 'development';
+
+    // Initialize the registry with service configurations
+    this.registry = {
+      'amplify-manager': this.parseServiceConfig('AMPLIFY_MANAGER'),
+      'amplify-wallet': this.parseServiceConfig('AMPLIFY_WALLET'),
+    };
+  }
+
+  /**
+   * Get the configuration for a specific service
+   * @param serviceName The name of the service
+   * @returns The service configuration
+   */
+  getServiceConfig(serviceName: ServiceName): ServiceConfig {
+    const config = this.registry[serviceName];
+    if (!config) {
+      throw new Error(`Service configuration not found for: ${serviceName}`);
+    }
+    return config;
+  }
+
+  /**
+   * Get the base URL for a specific service
+   * @param serviceName The name of the service
+   * @returns The base URL for the service
+   */
+  getServiceBaseUrl(serviceName: ServiceName): string {
+    const config = this.getServiceConfig(serviceName);
+
+    // For local development, append port if provided
+    if (this.stage === 'development' && config.port) {
+      return `http://${config.host}:${config.port}`;
+    }
+
+    // For cloud environments, use the host as is (ALB DNS or domain)
+    return this.parseUrl(config.host);
+  }
+
+  /**
+   * Parse service configuration from environment variables
+   * @param serviceEnvPrefix The prefix for the service's environment variables
+   * @param stage The current deployment stage
+   * @returns The parsed service configuration
+   */
+  private parseServiceConfig(serviceEnvPrefix: string): ServiceConfig {
+    // For different environments, use the appropriate host
+    // e.g., AMPLIFY_MANAGER_HOST for local, AMPLIFY_MANAGER_STAGING_HOST for staging
+    const host = process.env[`${serviceEnvPrefix}_HOST`];
+    if (!host) {
+      throw new Error(`Host not configured for service: ${serviceEnvPrefix}`);
+    }
+
+    // Only parse port for local development
+    const port =
+      this.stage === 'development'
+        ? parseInt(process.env[`${serviceEnvPrefix}_PORT`] || '0', 10) ||
+          undefined
+        : undefined;
+
+    return { host, port };
+  }
+
+  private parseUrl(baseUrl: string) {
+    const urlObject = new URL(baseUrl);
+    urlObject.port = '';
+    const urlWithoutPort = urlObject.toString();
+    return urlWithoutPort.replace(/\/$/, ''); // Remove trailing slash if present
+  }
+}

--- a/src/common/types/service.types.ts
+++ b/src/common/types/service.types.ts
@@ -1,0 +1,6 @@
+export const ServiceNames = {
+  AMPLIFY_MANAGER: 'amplify-manager',
+  AMPLIFY_WALLET: 'amplify-wallet',
+} as const;
+
+export type ServiceName = (typeof ServiceNames)[keyof typeof ServiceNames];

--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -10,6 +10,7 @@ import {
   WaitlistSchema,
   BrandAssetSchema,
   CampaignSchema,
+  WalletSchema,
 } from './schema';
 import { FeedbackSchema } from './schema/feedback.schema';
 
@@ -34,6 +35,7 @@ import { FeedbackSchema } from './schema/feedback.schema';
       { name: 'feedbacks', schema: FeedbackSchema },
       { name: 'brand-assets', schema: BrandAssetSchema },
       { name: 'campaigns', schema: CampaignSchema },
+      { name: 'wallets', schema: WalletSchema },
     ]),
   ],
   exports: [MongooseModule],

--- a/src/database/schema/index.ts
+++ b/src/database/schema/index.ts
@@ -4,3 +4,4 @@ export * from './business.schema';
 export * from './waitlist.schema';
 export * from './brand-assets.schema';
 export * from './campaign.schema';
+export * from './wallet.schema';

--- a/src/database/schema/user.schema.ts
+++ b/src/database/schema/user.schema.ts
@@ -1,5 +1,5 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { HydratedDocument } from 'mongoose';
+import { HydratedDocument, Types } from 'mongoose';
 
 export type UserDoc = HydratedDocument<User>;
 
@@ -80,6 +80,12 @@ export class User {
 
   @Prop({ enum: ['active', 'past_due', 'canceled', 'none'], default: 'none' })
   paymentStatus?: string;
+
+  @Prop({ enum: ['free', 'starter', 'grow', 'scale'], default: 'free' })
+  planTier: string;
+
+  @Prop({ type: Types.ObjectId, ref: 'wallets', required: false })
+  walletId?: string;
 }
 
 export const UserSchema = SchemaFactory.createForClass(User);

--- a/src/database/schema/wallet.schema.ts
+++ b/src/database/schema/wallet.schema.ts
@@ -1,0 +1,39 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument, Types } from 'mongoose';
+
+export type WalletDocument = HydratedDocument<Wallet>;
+
+@Schema({ timestamps: true })
+export class Wallet {
+  @Prop({
+    type: Types.ObjectId,
+    ref: 'users',
+    required: true,
+    unique: true,
+    index: true,
+  })
+  userId: Types.ObjectId;
+
+  @Prop({
+    type: Number,
+    required: true,
+    default: 0,
+  })
+  balance: number; //stored in cents
+
+  @Prop({
+    type: String,
+    required: true,
+    default: 'USD',
+  })
+  currency: string;
+
+  @Prop({
+    type: String,
+    enum: ['ACTIVE', 'FROZEN', 'CLOSED'],
+    default: 'ACTIVE',
+  })
+  status: string;
+}
+
+export const WalletSchema = SchemaFactory.createForClass(Wallet);


### PR DESCRIPTION
Add wallet service integration to enforce subscription-based campaign limits and handle payment processing during campaign creation. Includes internal HTTP helper for service communication and comprehensive error handling for insufficient funds scenarios.

- Add the env variable for AMPLIFY wallet just like we did for AMPLIFY manager , for service-to-service communication